### PR TITLE
Add target tests

### DIFF
--- a/odoh_server.go
+++ b/odoh_server.go
@@ -139,7 +139,7 @@ func main() {
 	endpoints["Health"] = healthEndpoint
 	endpoints["Config"] = configEndpoint
 
-	resolversInUse := make([]*targetResolver, len(nameServers))
+	resolversInUse := make([]resolver, len(nameServers))
 
 	for index := 0; index < len(nameServers); index++ {
 		resolver := &targetResolver{

--- a/odoh_server.go
+++ b/odoh_server.go
@@ -54,9 +54,6 @@ const (
 	healthEndpoint = "/health"
 	configEndpoint = "/.well-known/odohconfigs"
 
-	// WebPvD configuration. Fill in your values here.
-	webPvDString = `"{ "identifier" : "github.com", "expires" : "2019-08-23T06:00:00Z", "prefixes" : [ ], "dnsZones" : [ "odoh.example.net" ] }"`
-
 	// Environment variables
 	secretSeedEnvironmentVariable    = "SEED_SECRET_KEY"
 	targetNameEnvironmentVariable    = "TARGET_INSTANCE_NAME"

--- a/proxy.go
+++ b/proxy.go
@@ -37,10 +37,10 @@ type proxyServer struct {
 }
 
 var (
-	ErrWrongMethod       = fmt.Errorf("Unsupported method")
-	ErrMissingTargetHost = fmt.Errorf("Missing proxy targethost query parameter")
-	ErrMissingTargetPath = fmt.Errorf("Missing proxy targetpath query parameter")
-	ErrEmptyRequestBody  = fmt.Errorf("Missing request body")
+	errWrongMethod       = fmt.Errorf("Unsupported method")
+	errMissingTargetHost = fmt.Errorf("Missing proxy targethost query parameter")
+	errMissingTargetPath = fmt.Errorf("Missing proxy targetpath query parameter")
+	errEmptyRequestBody  = fmt.Errorf("Missing request body")
 )
 
 func forwardProxyRequest(client *http.Client, targetName string, targetPath string, body []byte, headerContentType string) (*http.Response, error) {
@@ -59,7 +59,7 @@ func (p *proxyServer) proxyQueryHandler(w http.ResponseWriter, r *http.Request) 
 	log.Printf("%s Handling %s\n", r.Method, r.URL.Path)
 
 	if r.Method != "POST" {
-		p.lastError = ErrWrongMethod
+		p.lastError = errWrongMethod
 		log.Printf(p.lastError.Error())
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
@@ -67,7 +67,7 @@ func (p *proxyServer) proxyQueryHandler(w http.ResponseWriter, r *http.Request) 
 
 	targetName := r.URL.Query().Get("targethost")
 	if targetName == "" {
-		p.lastError = ErrMissingTargetHost
+		p.lastError = errMissingTargetHost
 		log.Printf(p.lastError.Error())
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
@@ -75,7 +75,7 @@ func (p *proxyServer) proxyQueryHandler(w http.ResponseWriter, r *http.Request) 
 
 	targetPath := r.URL.Query().Get("targetpath")
 	if targetPath == "" {
-		p.lastError = ErrMissingTargetPath
+		p.lastError = errMissingTargetPath
 		log.Printf(p.lastError.Error())
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return
@@ -84,7 +84,7 @@ func (p *proxyServer) proxyQueryHandler(w http.ResponseWriter, r *http.Request) 
 	defer r.Body.Close()
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil || len(body) == 0 {
-		p.lastError = ErrEmptyRequestBody
+		p.lastError = errEmptyRequestBody
 		log.Printf(p.lastError.Error())
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -66,8 +66,8 @@ func TestProxyMethod(t *testing.T) {
 	if status := rr.Code; status != http.StatusBadRequest {
 		t.Fatal(fmt.Errorf("Failed when sent an invalid request method. Expected %d, got %d", http.StatusBadRequest, status))
 	}
-	if proxy.lastError != ErrWrongMethod {
-		t.Fatal(fmt.Errorf("Incorrect error. Expected %s", ErrWrongMethod.Error()))
+	if proxy.lastError != errWrongMethod {
+		t.Fatal(fmt.Errorf("Incorrect error. Expected %s", errWrongMethod.Error()))
 	}
 }
 
@@ -96,8 +96,8 @@ func TestProxyQueryParametersMissing(t *testing.T) {
 		if status := rr.Code; status != http.StatusBadRequest {
 			t.Fatal(fmt.Errorf("Failed when sent invalid parameters. Expected %d, got %d", http.StatusBadRequest, status))
 		}
-		if proxy.lastError != ErrMissingTargetHost {
-			t.Fatal(fmt.Errorf("Incorrect error. Expected %s", ErrMissingTargetHost.Error()))
+		if proxy.lastError != errMissingTargetHost {
+			t.Fatal(fmt.Errorf("Incorrect error. Expected %s", errMissingTargetHost.Error()))
 		}
 	}
 
@@ -117,8 +117,8 @@ func TestProxyQueryParametersMissing(t *testing.T) {
 		if status := rr.Code; status != http.StatusBadRequest {
 			t.Fatal(fmt.Errorf("Failed when sent invalid parameters. Expected %d, got %d", http.StatusBadRequest, status))
 		}
-		if proxy.lastError != ErrMissingTargetPath {
-			t.Fatal(fmt.Errorf("Incorrect error. Expected %s", ErrMissingTargetPath.Error()))
+		if proxy.lastError != errMissingTargetPath {
+			t.Fatal(fmt.Errorf("Incorrect error. Expected %s", errMissingTargetPath.Error()))
 		}
 	}
 }
@@ -140,8 +140,8 @@ func TestProxyQueryMissingBody(t *testing.T) {
 	if status := rr.Code; status != http.StatusBadRequest {
 		t.Fatal(fmt.Errorf("Failed when sent invalid parameters. Expected %d, got %d", http.StatusBadRequest, status))
 	}
-	if proxy.lastError != ErrEmptyRequestBody {
-		t.Fatal(fmt.Errorf("Incorrect error. Expected %s", ErrEmptyRequestBody.Error()))
+	if proxy.lastError != errEmptyRequestBody {
+		t.Fatal(fmt.Errorf("Incorrect error. Expected %s", errEmptyRequestBody.Error()))
 	}
 }
 

--- a/resolver.go
+++ b/resolver.go
@@ -24,17 +24,23 @@ package main
 
 import (
 	"fmt"
-	"github.com/miekg/dns"
 	"net"
 	"time"
+
+	"github.com/miekg/dns"
 )
+
+type resolver interface {
+	name() string
+	resolve(query *dns.Msg) (*dns.Msg, error)
+}
 
 type targetResolver struct {
 	nameserver string
 	timeout    time.Duration
 }
 
-func (s targetResolver) getResolverServerName() string {
+func (s targetResolver) name() string {
 	return s.nameserver
 }
 

--- a/target.go
+++ b/target.go
@@ -291,11 +291,6 @@ func (s *targetServer) obliviousQueryHandler(w http.ResponseWriter, r *http.Requ
 	w.Write(packedResponseMessage)
 }
 
-func (s *targetServer) serverWebPvD(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", r.Header.Get("Content-Type"))
-	w.Write([]byte(webPvDString))
-}
-
 func (s *targetServer) targetQueryHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("%s Handling %s\n", r.Method, r.URL.Path)
 

--- a/target_test.go
+++ b/target_test.go
@@ -1,0 +1,104 @@
+// The MIT License
+//
+// Copyright (c) 2020, Cloudflare, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	odoh "github.com/cloudflare/odoh-go"
+	"github.com/miekg/dns"
+)
+
+type localResolver struct {
+	queryResponseMap map[string][]byte // Packed DNS queries to responses
+}
+
+func (r localResolver) name() string {
+	return "localResolver"
+}
+
+func (r localResolver) resolve(query *dns.Msg) (*dns.Msg, error) {
+	packedQuery, err := query.Pack()
+	if err != nil {
+		return nil, err
+	}
+
+	packed, ok := r.queryResponseMap[string(packedQuery)]
+	if !ok {
+		return nil, errors.New("Failed to resolve")
+	}
+
+	response := &dns.Msg{}
+	err = response.Unpack(packed)
+
+	return response, err
+}
+
+func TestConfigHandler(t *testing.T) {
+	seed := make([]byte, defaultSeedLength)
+	rand.Read(seed)
+
+	keyPair, err := odoh.CreateKeyPairFromSeed(kemID, kdfID, aeadID, seed)
+	if err != nil {
+		t.Fatal("Failed to create a private key. Exiting now.")
+	}
+
+	configSet := []odoh.ObliviousDoHConfig{keyPair.Config}
+	configs := odoh.CreateObliviousDoHConfigs(configSet)
+	marshalledConfig := configs.Marshal()
+
+	target := targetServer{
+		resolver:    []resolver{&localResolver{}},
+		odohKeyPair: keyPair,
+	}
+
+	handler := http.HandlerFunc(target.configHandler)
+
+	request, err := http.NewRequest("GET", configEndpoint, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, request)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Fatal(fmt.Errorf("Failed request with error code: %d", status))
+	}
+
+	body, err := ioutil.ReadAll(rr.Result().Body)
+	if err != nil {
+		t.Fatal("Failed to read body:", err)
+	}
+
+	if !bytes.Equal(body, marshalledConfig) {
+		t.Fatal("Received invalid config")
+	}
+}

--- a/target_test.go
+++ b/target_test.go
@@ -25,9 +25,11 @@ package main
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -37,6 +39,7 @@ import (
 )
 
 type localResolver struct {
+	queries          []string
 	queryResponseMap map[string][]byte // Packed DNS queries to responses
 }
 
@@ -61,7 +64,44 @@ func (r localResolver) resolve(query *dns.Msg) (*dns.Msg, error) {
 	return response, err
 }
 
-func TestConfigHandler(t *testing.T) {
+func createLocalResolver(t *testing.T) *localResolver {
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	packedQuery, err := q.Pack()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := new(dns.Msg)
+	r.SetReply(q)
+	r.Answer = make([]dns.RR, 1)
+	r.Answer[0] = &dns.A{
+		Hdr: dns.RR_Header{
+			Name:   q.Question[0].Name,
+			Rrtype: dns.TypeA,
+			Class:  dns.ClassINET,
+			Ttl:    0,
+		},
+		A: net.ParseIP("127.0.0.1"),
+	}
+	packedResponse, err := r.Pack()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	queries := make([]string, 0)
+	queries = append(queries, string(packedQuery))
+
+	resultMap := make(map[string][]byte)
+	resultMap[string(packedQuery)] = packedResponse
+
+	return &localResolver{
+		queries:          queries,
+		queryResponseMap: resultMap,
+	}
+}
+
+func createTarget(t *testing.T, r resolver) targetServer {
 	seed := make([]byte, defaultSeedLength)
 	rand.Read(seed)
 
@@ -70,14 +110,20 @@ func TestConfigHandler(t *testing.T) {
 		t.Fatal("Failed to create a private key. Exiting now.")
 	}
 
-	configSet := []odoh.ObliviousDoHConfig{keyPair.Config}
+	return targetServer{
+		resolver:        []resolver{r},
+		odohKeyPair:     keyPair,
+		telemetryClient: getTelemetryInstance("LOG"),
+	}
+}
+
+func TestConfigHandler(t *testing.T) {
+	r := createLocalResolver(t)
+	target := createTarget(t, r)
+
+	configSet := []odoh.ObliviousDoHConfig{target.odohKeyPair.Config}
 	configs := odoh.CreateObliviousDoHConfigs(configSet)
 	marshalledConfig := configs.Marshal()
-
-	target := targetServer{
-		resolver:    []resolver{&localResolver{}},
-		odohKeyPair: keyPair,
-	}
 
 	handler := http.HandlerFunc(target.configHandler)
 
@@ -100,5 +146,112 @@ func TestConfigHandler(t *testing.T) {
 
 	if !bytes.Equal(body, marshalledConfig) {
 		t.Fatal("Received invalid config")
+	}
+}
+func TestQueryHandlerInvalidContentType(t *testing.T) {
+	r := createLocalResolver(t)
+	target := createTarget(t, r)
+
+	handler := http.HandlerFunc(target.targetQueryHandler)
+
+	request, err := http.NewRequest("GET", queryEndpoint, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Add("Content-Type", "application/not-the-droids-youre-looking-for")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, request)
+
+	if status := rr.Result().StatusCode; status != http.StatusBadRequest {
+		t.Fatal(fmt.Errorf("Result did not yield %d, got %d instead", http.StatusBadRequest, status))
+	}
+}
+
+func TestQueryHandlerDoHWithPOST(t *testing.T) {
+	r := createLocalResolver(t)
+	target := createTarget(t, r)
+
+	handler := http.HandlerFunc(target.targetQueryHandler)
+
+	q := r.queries[0]
+	request, err := http.NewRequest(http.MethodPost, queryEndpoint, bytes.NewReader([]byte(q)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Add("Content-Type", dnsMessageContentType)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, request)
+
+	if status := rr.Result().StatusCode; status != http.StatusOK {
+		t.Fatal(fmt.Errorf("Result did not yield %d, got %d instead", http.StatusOK, status))
+	}
+	if rr.Result().Header.Get("Content-Type") != dnsMessageContentType {
+		t.Fatal("Invalid content type response")
+	}
+
+	responseBody, err := ioutil.ReadAll(rr.Result().Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(responseBody, r.queryResponseMap[q]) {
+		t.Fatal("Incorrect response received")
+	}
+}
+
+func TestQueryHandlerDoHWithGET(t *testing.T) {
+	r := createLocalResolver(t)
+	target := createTarget(t, r)
+
+	handler := http.HandlerFunc(target.targetQueryHandler)
+
+	q := r.queries[0]
+	encodedQuery := base64.RawURLEncoding.EncodeToString([]byte(q))
+
+	request, err := http.NewRequest(http.MethodGet, queryEndpoint+"?dns="+encodedQuery, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Add("Content-Type", dnsMessageContentType)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, request)
+
+	if status := rr.Result().StatusCode; status != http.StatusOK {
+		t.Fatal(fmt.Errorf("Result did not yield %d, got %d instead", http.StatusOK, status))
+	}
+	if rr.Result().Header.Get("Content-Type") != dnsMessageContentType {
+		t.Fatal("Invalid content type response")
+	}
+
+	responseBody, err := ioutil.ReadAll(rr.Result().Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(responseBody, r.queryResponseMap[q]) {
+		t.Fatal("Incorrect response received")
+	}
+}
+
+func TestQueryHandlerDoHWithInvalidMethod(t *testing.T) {
+	r := createLocalResolver(t)
+	target := createTarget(t, r)
+
+	handler := http.HandlerFunc(target.targetQueryHandler)
+
+	q := r.queries[0]
+	encodedQuery := base64.RawURLEncoding.EncodeToString([]byte(q))
+	request, err := http.NewRequest(http.MethodPut, queryEndpoint+"?dns="+encodedQuery, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Add("Content-Type", dnsMessageContentType)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, request)
+
+	if status := rr.Result().StatusCode; status != http.StatusBadRequest {
+		t.Fatal(fmt.Errorf("Result did not yield %d, got %d instead", http.StatusBadRequest, status))
 	}
 }


### PR DESCRIPTION
This is just a start of the relevant code paths. We might consider just removing telemetry, or creating a specialized target implementation that uses it, so the default code path is more lean.