### PR TITLE
Add TLS support to the server along with running instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,36 @@
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 [![deploy to Scalingo](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy)
 
+# Local development
+
+To deploy the server locally, first acquire a TLS certificate using [mkcert](https://github.com/FiloSottile/mkcert) as follows:
+
+~~~
+$ mkcert -key-file key.pem -cert-file cert.pem 127.0.0.1 localhost
+~~~
+
+Then build and run the server as follows:
+
+~~~
+$ make all
+$ CERT=cert.pem KEY=key.pem PORT=4567 ./odoh-server
+~~~
+
+You may then run the [corresponding client](https://github.com/cloudflare/odoh-client-go) as follows:
+
+~~~
+$ ./odoh-client odoh --proxy localhost:4567 --target odoh.cloudflare-dns.com --domain cloudflare.com
+;; opcode: QUERY, status: NOERROR, id: 14306
+;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 0
+
+;; QUESTION SECTION:
+;cloudflare.com.	IN	 AAAA
+
+;; ANSWER SECTION:
+cloudflare.com.	271	IN	AAAA	2606:4700::6810:84e5
+cloudflare.com.	271	IN	AAAA	2606:4700::6810:85e5
+~~~
+
 # Usage
 
 To deploy, run:

--- a/odoh_server.go
+++ b/odoh_server.go
@@ -59,6 +59,8 @@ const (
 	targetNameEnvironmentVariable    = "TARGET_INSTANCE_NAME"
 	experimentIDEnvironmentVariable  = "EXPERIMENT_ID"
 	telemetryTypeEnvironmentVariable = "TELEMETRY_TYPE"
+	certificateEnvironmentVariable   = "CERT"
+	keyEnvironmentVariable           = "KEY"
 )
 
 var (
@@ -116,13 +118,23 @@ func main() {
 	log.Printf("Setting Server Name as %v", serverName)
 
 	var experimentID string
-	if experimentID := os.Getenv(experimentIDEnvironmentVariable); experimentID == "" {
+	if experimentID = os.Getenv(experimentIDEnvironmentVariable); experimentID == "" {
 		experimentID = "EXP_LOCAL"
 	}
 
 	var telemetryType string
-	if telemetryType := os.Getenv(telemetryTypeEnvironmentVariable); telemetryType == "" {
+	if telemetryType = os.Getenv(telemetryTypeEnvironmentVariable); telemetryType == "" {
 		telemetryType = "LOG"
+	}
+
+	var certFile string
+	if certFile = os.Getenv(certificateEnvironmentVariable); certFile == "" {
+		certFile = "cert.pem"
+	}
+
+	var keyFile string
+	if keyFile = os.Getenv(keyEnvironmentVariable); keyFile == "" {
+		keyFile = "key.pem"
 	}
 
 	keyPair, err := odoh.CreateKeyPairFromSeed(kemID, kdfID, aeadID, seed)
@@ -177,6 +189,6 @@ func main() {
 	http.HandleFunc(configEndpoint, target.configHandler)
 	http.HandleFunc("/", server.indexHandler)
 
-	log.Printf("Listening on port %v\n", port)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
+	log.Printf("Listening on port %v with cert %v and key %v\n", port, certFile, keyFile)
+	log.Fatal(http.ListenAndServeTLS(fmt.Sprintf(":%s", port), certFile, keyFile, nil))
 }


### PR DESCRIPTION
This unblocks proxy deployment.