### PR TITLE
Setting go version for heroku build and disable need for CERT/KEY

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ./bin/odoh-server
+web: ./bin/odoh-server-go

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/cloudflare/odoh-server-go
 
+// +heroku goVersion go1.14
+// +scalingo goVersion go1.14
 go 1.14
 
 require (

--- a/odoh_server.go
+++ b/odoh_server.go
@@ -133,8 +133,10 @@ func main() {
 	}
 
 	var keyFile string
+	enableTLSServe := true
 	if keyFile = os.Getenv(keyEnvironmentVariable); keyFile == "" {
 		keyFile = "key.pem"
+		enableTLSServe = false
 	}
 
 	keyPair, err := odoh.CreateKeyPairFromSeed(kemID, kdfID, aeadID, seed)
@@ -189,6 +191,12 @@ func main() {
 	http.HandleFunc(configEndpoint, target.configHandler)
 	http.HandleFunc("/", server.indexHandler)
 
-	log.Printf("Listening on port %v with cert %v and key %v\n", port, certFile, keyFile)
-	log.Fatal(http.ListenAndServeTLS(fmt.Sprintf(":%s", port), certFile, keyFile, nil))
+	if enableTLSServe {
+		log.Printf("Listening on port %v with cert %v and key %v\n", port, certFile, keyFile)
+		log.Fatal(http.ListenAndServeTLS(fmt.Sprintf(":%s", port), certFile, keyFile, nil))
+	} else {
+		log.Printf("Listening on port %v without enabling TLS\n", port)
+		log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
+	}
+
 }


### PR DESCRIPTION
- Heroku/Scalingo manage certificates for the deployments and the need
  for CERT, KEY cause issues due to Procfile limitations
- The issues are similar for GAE deployments and services which manage certs